### PR TITLE
README: correct config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker create \
   -e DELAY=60 \
   -e TOKEN=InsertToken \
   -e CHATID=InsertChatID \
-  -v /path/to/host/config:/config \
+  -v /path/to/host/config:/app/config \
   --restart unless-stopped \
   bokker/rss.to.telegram
 ```


### PR DESCRIPTION
There is a wrong in-container config path in README.
To make config persistent we should use /app/config path instead.